### PR TITLE
epochの数を絞るparserをつけた。

### DIFF
--- a/train.py
+++ b/train.py
@@ -22,14 +22,14 @@ parser.add_argument('--no-cuda', action='store_true', default=False, help='Disab
 parser.add_argument('--fastmode', action='store_true', default=False, help='Validate during training pass.')
 parser.add_argument('--sparse', action='store_true', default=False, help='GAT with sparse version or not.')
 parser.add_argument('--seed', type=int, default=72, help='Random seed.')
-parser.add_argument('--epochs', type=int, default=10000, help='Number of epochs to train.')
+parser.add_argument('--epochs', type=int, default=200, help='Number of epochs to train.')
 parser.add_argument('--lr', type=float, default=0.005, help='Initial learning rate.')
 parser.add_argument('--weight_decay', type=float, default=5e-4, help='Weight decay (L2 loss on parameters).')
 parser.add_argument('--hidden', type=int, default=8, help='Number of hidden units.')
 parser.add_argument('--nb_heads', type=int, default=8, help='Number of head attentions.')
 parser.add_argument('--dropout', type=float, default=0.6, help='Dropout rate (1 - keep probability).')
 parser.add_argument('--alpha', type=float, default=0.2, help='Alpha for the leaky_relu.')
-parser.add_argument('--patience', type=int, default=100, help='Patience')
+parser.add_argument('--patience', type=int, default=20, help='Patience')
 parser.add_argument('--trajectory_prediction', action='store_true', default=False, 
                     help='Enable trajectory prediction mode with ADE/FDE evaluation.')
 


### PR DESCRIPTION
## 追加された機能

**1. ADE/FDE計算関数：**
compute_ade(): 軌道全体の平均変位誤差を計算
compute_fde(): 最終位置での変位誤差を計算
evaluate_trajectory_metrics(): ADE/FDEを評価する統合関数


**2. 軌道予測モード：**
--trajectory_predictionフラグで軌道予測モードを有効化
MSE損失を使用（分類用のNLL損失の代わり）
ADE/FDE指標での評価


**3.柔軟な評価：**
分類タスクでは従来のaccuracy
軌道予測タスクではADE/FDE
結果をファイルに保存

## 変更点
デフォルトepoch数: 10,000 → 200
Early stopping patience: 100 → 20